### PR TITLE
Detect server disconnection after NBD_OPT_EXPORTNAME

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -283,7 +283,9 @@ void negotiate(int sock, u64 *rsize64, u32 *flags, char* name, uint32_t needed_f
 		printf(".");
 	}
 
-	if (read(sock, &size64, sizeof(size64)) < 0)
+	if (read(sock, &size64, sizeof(size64)) <= 0)
+		if (errno == 0)
+			err("Server closed connection");
 		err("Failed/3: %m\n");
 	size64 = ntohll(size64);
 


### PR DESCRIPTION
If the export is unknown to the server, it may disconnect (new-style handshake un-fixed). In that case the read call to get export size may return 0 (non error, EOF).

This change fixes following error:

```
nbd-client -N unexistent 127.0.0.1 /dev/nbd0
Negotiation: ..size = 2314498962MBError: Exported device is too big for me. Get 64-bit machine :-(

Exiting.
```
