### PR TITLE
Disable swap option on Android.

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -403,8 +403,10 @@ void finish_sock(int sock, int nbd, int swap) {
 	if (ioctl(nbd, NBD_SET_SOCK, sock) < 0)
 		err("Ioctl NBD_SET_SOCK failed: %m\n");
 
+#ifndef __ANDROID__
 	if (swap)
 		mlockall(MCL_CURRENT | MCL_FUTURE);
+#endif
 }
 
 static int
@@ -596,6 +598,11 @@ int main(int argc, char *argv[]) {
 			exit(EXIT_FAILURE);
 		}
 	}
+
+#ifdef __ANDROID__
+  if (swap)
+    err("swap option unsupported on Android because mlockall is unsupported.");
+#endif
 
 	if((!port && !name) || !hostname || !nbddev) {
 		usage("not enough information specified");


### PR DESCRIPTION
Hi, this is a followup on http://sourceforge.net/p/nbd/mailman/message/32862671/.

I've added options to disable the swap option when compiling for
with android-18, arm-linux-androideabi-4.8, and the Android NDK r10b.
I'm using the below snippet to create a standalone toolchain
and compile, and I'll try to keep my post at
http://bamos.github.io/2014/09/08/nbd-android/ synchronized
with the master branch of nbd, so feel free tag me if
any changes are made to this.

Regards,
Brandon.

---

die() { echo $*; return -1; }
touch man/nbd-{client.8,server.{1,5},trdump.1}.sh.in
autoreconf -f -i || die "autoreconf failed."

$ANDROID_NDK/build/tools/make-standalone-toolchain.sh \
  --platform=android-18 \
  --toolchain=arm-linux-androideabi-4.8 \
  --install-dir=$PWD/toolchain

pathadd() { PATH="${PATH:+"$PATH:"}$1"; }
pathadd "$PWD/toolchain/bin"
command -v arm-linux-androideabi-gcc &> /dev/null || exit -1
export SYSROOT=$PWD/toolchain/sysroot
export CC="arm-linux-androideabi-gcc --sysroot=$SYSROOT"
export CXX=arm-linux-androideabi-g++
export LD=arm-linux-androideabi-ld
export RANLIB=arm-linux-androideabi-ranlib
export AR=arm-linux-androideabi-ar
export CROSS_PREFIX=arm-linux-androideabi-
export CFLAGS='-march=armv7-a -mfloat-abi=softfp -mfpu=neon'
export LDFLAGS='-Wl,--fix-cortex-a8'

./configure --host=armv7-unknown-linux --target=armv7-unknown-linux \
  || die "configure failed"
make nbd-client
