### PR TITLE
use uint32_t & uint64_t instead of u32 & u64, and fix #includes

### DIFF
--- a/cliserv.c
+++ b/cliserv.c
@@ -1,4 +1,5 @@
 #include <config.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <syslog.h>
@@ -9,9 +10,9 @@
 #include <cliserv.h>
 #include <nbd-debug.h>
 
-const u64 cliserv_magic = 0x00420281861253LL;
-const u64 opts_magic = 0x49484156454F5054LL;
-const u64 rep_magic = 0x3e889045565a9LL;
+const uint64_t cliserv_magic = 0x00420281861253LL;
+const uint64_t opts_magic = 0x49484156454F5054LL;
+const uint64_t rep_magic = 0x3e889045565a9LL;
 
 /**
  * Set a socket to blocking or non-blocking
@@ -93,8 +94,8 @@ uint64_t ntohll(uint64_t a) {
 }
 #else
 uint64_t ntohll(uint64_t a) {
-	u32 lo = a & 0xffffffff;
-	u32 hi = a >> 32U;
+	uint32_t lo = a & 0xffffffff;
+	uint32_t hi = a >> 32U;
 	lo = ntohl(lo);
 	hi = ntohl(hi);
 	return ((uint64_t) lo) << 32U | hi;

--- a/cliserv.h
+++ b/cliserv.h
@@ -9,36 +9,14 @@
    Send 128 bytes of zeros (reserved for future use)
  */
 
-#include <errno.h>
 #include <string.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 
-#if SIZEOF_UNSIGNED_SHORT_INT==4
-typedef unsigned short u32;
-#elif SIZEOF_UNSIGNED_INT==4
-typedef unsigned int u32;
-#elif SIZEOF_UNSIGNED_LONG_INT==4
-typedef unsigned long u32;
-#else
-#error I need at least some 32-bit type
-#endif
+#include "config.h"
 
-#if SIZEOF_UNSIGNED_INT==8
-typedef unsigned int u64;
-#elif SIZEOF_UNSIGNED_LONG_INT==8
-typedef unsigned long u64;
-#elif SIZEOF_UNSIGNED_LONG_LONG_INT==8
-typedef unsigned long long u64;
-#else
-#error I need at least some 64-bit type
-#endif
-
-#define __be32 u32
-#define __be64 u64
-#include "nbd.h"
 
 #ifndef HAVE_FDATASYNC
 #define fdatasync(arg) fsync(arg)
@@ -64,9 +42,9 @@ typedef unsigned long long u64;
 #endif
 #endif
 
-extern const u64 cliserv_magic;
-extern const u64 opts_magic;
-extern const u64 rep_magic;
+extern const uint64_t cliserv_magic;
+extern const uint64_t opts_magic;
+extern const uint64_t rep_magic;
 
 #define INIT_PASSWD "NBDMAGIC"
 

--- a/nbd-server.c
+++ b/nbd-server.c
@@ -1573,7 +1573,7 @@ int expread(READ_CTX *ctx, CLIENT *client) {
 			len : (size_t)DIFFPAGESIZE-offset;
 		if (!(client->server->flags & F_COPYONWRITE))
 			pthread_rwlock_rdlock(&client->export_lock);
-		if (client->difmap[mapcnt]!=(u32)(-1)) { /* the block is already there */
+		if (client->difmap[mapcnt]!=(uint32_t)(-1)) { /* the block is already there */
 			DEBUG("Page %llu is at %lu\n", (unsigned long long)mapcnt,
 			       (unsigned long)(client->difmap[mapcnt]));
 			char *buf = find_read_buf(ctx);
@@ -1642,7 +1642,7 @@ int expwrite(off_t a, char *buf, size_t len, CLIENT *client, int fua) {
 
 		if (!(client->server->flags & F_COPYONWRITE))
 			pthread_rwlock_rdlock(&client->export_lock);
-		if (client->difmap[mapcnt]!=(u32)(-1)) { /* the block is already there */
+		if (client->difmap[mapcnt]!=(uint32_t)(-1)) { /* the block is already there */
 			DEBUG("Page %llu is at %lu\n", (unsigned long long)mapcnt,
 			       (unsigned long)(client->difmap[mapcnt])) ;
 			if (pwrite(client->difffile, buf, wrlen, client->difmap[mapcnt]*DIFFPAGESIZE+offset) != wrlen) goto fail;
@@ -1942,7 +1942,7 @@ int commit_diff(CLIENT* client, bool lock, int fhandle){
 		offset = DIFFPAGESIZE*i;
 		if (lock)
 			pthread_rwlock_wrlock(&client->export_lock);
-		if (client->difmap[i] != (u32)-1){
+		if (client->difmap[i] != (uint32_t)-1){
 			dirtycount += 1;
 			DEBUG("flushing dirty page %d, offset %ld\n", i, offset);
 			if (pread(client->difffile, buf, DIFFPAGESIZE, client->difmap[i]*DIFFPAGESIZE) != DIFFPAGESIZE) {
@@ -1959,7 +1959,7 @@ int commit_diff(CLIENT* client, bool lock, int fhandle){
 				}
 				break;
 			}
-			client->difmap[i] = (u32)-1;
+			client->difmap[i] = (uint32_t)-1;
 		}
 		if (lock)
 			pthread_rwlock_unlock(&client->export_lock);
@@ -2155,17 +2155,17 @@ bool copyonwrite_prepare(CLIENT* client) {
 		err("Could not create diff file (%m)");
 		return false;
 	}
-	if ((client->difmap=calloc(client->exportsize/DIFFPAGESIZE,sizeof(u32)))==NULL) {
+	if ((client->difmap=calloc(client->exportsize/DIFFPAGESIZE,sizeof(uint32_t)))==NULL) {
 		err("Could not allocate memory");
 		return false;
 	}
-	for (i=0;i<client->exportsize/DIFFPAGESIZE;i++) client->difmap[i]=(u32)-1;
+	for (i=0;i<client->exportsize/DIFFPAGESIZE;i++) client->difmap[i]=(uint32_t)-1;
 
 	return true;
 }
 
 void send_export_info(CLIENT* client, SERVER* server, bool maybe_zeroes) {
-	uint64_t size_host = htonll((u64)(client->exportsize));
+	const uint64_t size_host = htonll((uint64_t)(client->exportsize));
 	uint16_t flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_WRITE_ZEROES;
 
 	socket_write(client, &size_host, 8);

--- a/nbd-trplay.c
+++ b/nbd-trplay.c
@@ -8,6 +8,7 @@
  * (C) Robert Bosch GmbH, 2021
  */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <stdio.h>

--- a/nbd.h
+++ b/nbd.h
@@ -17,6 +17,8 @@
 
 //#include <linux/types.h>
 
+#include <stdint.h>
+
 #define NBD_SET_SOCK	_IO( 0xab, 0 )
 #define NBD_SET_BLKSIZE	_IO( 0xab, 1 )
 #define NBD_SET_SIZE	_IO( 0xab, 2 )

--- a/nbdsrv.c
+++ b/nbdsrv.c
@@ -228,7 +228,7 @@ SERVER* dup_serve(const SERVER *const s) {
 
 uint64_t size_autodetect(int fhandle) {
 	off_t es;
-	u64 bytes __attribute__((unused));
+	uint64_t bytes __attribute__((unused));
 	struct stat stat_buf;
 	int error;
 

--- a/treefiles.c
+++ b/treefiles.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h> // for PATH_MAX
 #include <inttypes.h>


### PR DESCRIPTION
I'd favor to get rid of the non-standard typedefs `u32` and `u64` and use C99 standard types `uint32_t` and `uint64_t` everywhere. These types are already used in the project, but mixed wildly with the old types.

During this I also moved some #include directives so each .h includes only the headers to fulfill its own needs (e.g. to use foreign declarations for its own declarations). Headers that are only needed for the implementation are included only in the .c file.

Redundant or unneeded includes are removed at all.
