### PR TITLE
Fix nbd-client cannot find the index when the device name were given without /dev/ prefix

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -223,7 +223,7 @@ static void netlink_disconnect(char *nbddev) {
 
 	int index = -1;
 	if (nbddev) {
-		if (sscanf(nbddev, "/dev/nbd%d", &index) != 1)
+		if (sscanf(nbddev, "nbd%d", &index) != 1)
 			err("Invalid nbd device target\n");
 	}
 	if (index < 0)
@@ -1257,7 +1257,7 @@ int main(int argc, char *argv[]) {
 	if (netlink) {
 		int index = -1;
 		if (cur_client->dev) {
-			if (sscanf(cur_client->dev, "/dev/nbd%d", &index) != 1)
+			if (sscanf(cur_client->dev, "nbd%d", &index) != 1)
 				err("Invalid nbd device target\n");
 		}
 		netlink_configure(index, sockfds, cur_client->nconn,


### PR DESCRIPTION
`nbd-client nbd0` command uses /etc/nbdtab to connect to an nbd server.
This command prints "Error: Invalid nbd device target".

This will also cause systemctl to start the nbd service.