### PR TITLE
Fix compilation without libnl3

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -1710,6 +1710,7 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+#if HAVE_NETLINK
 	if (netlink) {
 		int index = -1;
 		if (cur_client->dev) {
@@ -1725,6 +1726,8 @@ int main(int argc, char *argv[]) {
 		
 		return 0;
 	}
+#endif
+
 	/* Go daemon */
 
 #ifndef NOFORK


### PR DESCRIPTION
Error is in the commit message. I'm not completely sure this is the "right" way to fix it.

Seen on void linux (musl lilbc) compilation. Just adding `libnl3-devel` to the dependencies also fixed the compilation failure (configure script then found it), thus avoiding the need for this patch. But that looks like working around the problem.

I still think this should be fixed at the code level, so here is an attempt.

WDYT ?