### PR TITLE
nbd-client: support device with and without '/dev/' prefix

### DIFF
--- a/nbd-client.c
+++ b/nbd-client.c
@@ -228,8 +228,11 @@ static void netlink_disconnect(char *nbddev) {
 
 	int index = -1;
 	if (nbddev) {
-		if (sscanf(nbddev, "nbd%d", &index) != 1)
-			err("Invalid nbd device target\n");
+		if (sscanf(nbddev, "/dev/nbd%d", &index) != 1) {
+			if (sscanf(nbddev, "nbd%d", &index) != 1) {
+				err("Invalid nbd device target\n");
+			}
+		}
 	}
 	if (index < 0)
 		err("Invalid nbd device target\n");
@@ -1539,8 +1542,11 @@ int main(int argc, char *argv[]) {
 	if (netlink) {
 		int index = -1;
 		if (cur_client->dev) {
-			if (sscanf(cur_client->dev, "nbd%d", &index) != 1)
-				err("Invalid nbd device target\n");
+			if (sscanf(cur_client->dev, "/dev/nbd%d", &index) != 1) {
+				if (sscanf(cur_client->dev, "nbd%d", &index) != 1) {
+					err("Invalid nbd device target\n");
+				}
+			}
 		}
 		netlink_configure(index, sockfds, flags, identifier);
 		


### PR DESCRIPTION
This broke with 8273f1edee33ce58e9468ed56f3d152f3f226eee, where prefix must not be given.

Fixes: https://github.com/NetworkBlockDevice/nbd/issues/187